### PR TITLE
add missions to falcon9

### DIFF
--- a/mission/mission.go
+++ b/mission/mission.go
@@ -1,0 +1,208 @@
+package f9mission
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/theckman/falcon9/crew"
+)
+
+// GNGSetting is the type that defines the behavior of the mission parameters for
+// blastoff. When the Go/No-Go call is made, how many "Go"s are required for
+// blastoff. The default value is to require all crew members vote Go.
+type GNGSetting uint8
+
+const (
+	// VoteAll is the GoNoGo setting for requiring that all crew members vote Go.
+	VoteAll GNGSetting = iota
+
+	// VoteQuorum is the GoNoGo setting for requiring that only a quorum number
+	// of crew members vote for blastoff. If there are too few crew members to
+	// reach quorum without all voting "Go", it falls back to GNGAll mode.
+	VoteQuorum
+)
+
+// ErrCrewMemberAlreadyPresent is the error returned from *Mission.AddUser
+// if the crew member is already present within the mission. Ths consumer
+// may not consider this an error condition.
+var ErrCrewMemberAlreadyPresent = errors.New("the user you are trying to add already exists")
+
+// ErrCrewMemberNotPresent is the error returned from RemoveCrew() if the crew member
+// is not assigned to this mission.
+var ErrCrewMemberNotPresent = errors.New("the crew member you've tried to remove is not present")
+
+var errUseNewMission = errors.New("use f9mission.NewMission() to create the *Mission struct")
+
+// InterfaceManageCrew is the mission-specific interface for adding crew members.
+type InterfaceManageCrew interface {
+	// AddCrew is a function to add a new crew member to this mission. If the crew
+	// member already exists (identified by their HashedKey), and replace is set to
+	// false, this will return an f9crew.ErrCrewMemberAlreadyPresent error. However,
+	// if replace is true it will simply replace the crew member with the new one.
+	//
+	// The latter is useful for a client quickly rejoining the session
+	// after a network interruption. This assume clients have a unique key.
+	AddCrew(crew f9crew.Interface, replace bool) error
+
+	// RemoveCrew is function to remove a crew member from the mission.
+	// The crew member's HashedKey is used to do the lookup for determining which
+	// crew member to remove from the mission. This returns the crew member being
+	// removed, if a consumer wishes to use it.
+	RemoveCrew(hashedKey string) (f9crew.Interface, error)
+
+	// Crew is a function that returns an f9crew.Manifest. This is a
+	// representation of the crew for the current mission. This function
+	// returns the values unsorted, but the returns value will have a
+	// Sort() method.
+	Crew() f9crew.Manifest
+}
+
+// InterfaceAccessors is an interface type for accessor methods of the
+// mission parameters.
+type InterfaceAccessors interface {
+	// Name returns the name of the mission. This is an optional value, so it
+	// may be set to an empty string ("").
+	Name() string
+
+	// ID returns the unique identifier of the mission.
+	ID() string
+
+	// GNGSetting returns the Go/No-Go setting for the mission.
+	GNGSetting() GNGSetting
+}
+
+// Interface is the interface representing a falcon9 mission. This allows consumers
+// to write their own mission logic if they wish to do so.
+type Interface interface {
+	InterfaceManageCrew
+	InterfaceAccessors
+}
+
+// MissionParams is a struct that consists of the parameters for a mission.
+type MissionParams struct {
+	ID     string
+	GoNoGo GNGSetting
+	Name   string
+}
+
+// Mission is the struct that implements the f9mission.Interface interface. This
+// represents a falcon9 mission and all of its parameters.
+type Mission struct {
+	id   string
+	name string
+	gng  GNGSetting
+
+	crew  map[string]f9crew.Interface
+	mapMu sync.Mutex
+}
+
+// NewMission is a function to provide a new mission with the provided parameters.
+func NewMission(mp *MissionParams) (*Mission, error) {
+	if mp == nil {
+		return nil, errors.New("mission parameters cannot be nil")
+	}
+
+	if mp.ID == "" {
+		return nil, errors.New("the ID of the mission cannot be an empty string")
+	}
+
+	m := &Mission{
+		id:   mp.ID,
+		name: mp.Name,
+		gng:  mp.GoNoGo,
+		crew: make(map[string]f9crew.Interface),
+	}
+
+	return m, nil
+}
+
+// Name returns the name of the mission. This is an optional value,
+// so it may be set to an empty string ("").
+func (m *Mission) Name() string { return m.name }
+
+// ID returns the unique identifier of the mission.
+func (m *Mission) ID() string { return m.id }
+
+// GNGSetting returns the Go/No-Go setting for the mission.
+func (m *Mission) GNGSetting() GNGSetting { return m.gng }
+
+// Crew is a function that returns an f9crew.Manifest. This is a
+// representation of the crew for the current mission. The slice
+// returned contains unsorted values, but the returns value will
+// have a Sort() method.
+func (m *Mission) Crew() f9crew.Manifest {
+	m.mapMu.Lock()
+	defer m.mapMu.Unlock()
+
+	manifest := make(f9crew.Manifest, len(m.crew))
+
+	var counter int
+
+	// loop over each item in the map
+	// and append to the f9crew.Manifest slice
+	for _, crew := range m.crew {
+		manifest[counter] = crew
+		counter++
+	}
+
+	return manifest
+}
+
+// AddCrew is a function to add a new crew member to this mission. If the crew
+// member already exists (identified by their HashedKey), and replace is set to
+// false, this will return an f9crew.ErrCrewMemberAlreadyPresent error. However,
+// if replace is true it will simply replace the crew member with the new one.
+//
+// The latter is useful for a client quickly rejoining the session
+// after a network interruption. This assume clients have a unique key.
+func (m *Mission) AddCrew(crew f9crew.Interface, replace bool) error {
+	// do some sanity checks before taking the mutex
+	// if the crew map is nil, this struct was improperly created
+	if m.crew == nil {
+		return errUseNewMission
+	}
+
+	if crew == nil {
+		return errors.New("a crew member cannot be nil")
+	}
+
+	m.mapMu.Lock()
+	defer m.mapMu.Unlock()
+
+	if _, ok := m.crew[crew.HashedKey()]; ok {
+		// if we aren't going to replace the user
+		// return an error
+		if !replace {
+			return ErrCrewMemberAlreadyPresent
+		}
+
+		delete(m.crew, crew.HashedKey())
+	}
+
+	m.crew[crew.HashedKey()] = crew
+
+	return nil
+}
+
+// RemoveCrew is function to remove a crew member from the mission.
+// The crew member's HashedKey is used to do the lookup for determining which
+// crew member to remove from the mission. This returns the crew member being
+// removed, if a consumer wishes to use it.
+func (m *Mission) RemoveCrew(hashedKey string) (f9crew.Interface, error) {
+	if hashedKey == "" {
+		return nil, errors.New("hashedKey parameter cannot be an empty string")
+	}
+
+	m.mapMu.Lock()
+	defer m.mapMu.Unlock()
+
+	crew, ok := m.crew[hashedKey]
+
+	if !ok {
+		return nil, ErrCrewMemberNotPresent
+	}
+
+	delete(m.crew, hashedKey)
+
+	return crew, nil
+}

--- a/mission/mission_test.go
+++ b/mission/mission_test.go
@@ -1,0 +1,164 @@
+package f9mission_test
+
+import (
+	"testing"
+
+	"github.com/theckman/falcon9/crew"
+	"github.com/theckman/falcon9/mission"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct {
+	mission *f9mission.Mission
+}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func addCrew(m *f9mission.Mission, c *C) {
+	crew, err := f9crew.NewCrewMember("Jebediah Kerman", "0")
+	c.Assert(err, IsNil)
+	c.Assert(m.AddCrew(crew, false), IsNil)
+
+	crew, err = f9crew.NewCrewMember("Bill Kerman", "1")
+	c.Assert(err, IsNil)
+	c.Assert(m.AddCrew(crew, false), IsNil)
+
+	crew, err = f9crew.NewCrewMember("Bob Kerman", "2")
+	c.Assert(err, IsNil)
+	c.Assert(m.AddCrew(crew, false), IsNil)
+}
+
+func (t *TestSuite) SetUpSuite(c *C) {
+	mission, err := f9mission.NewMission(
+		&f9mission.MissionParams{
+			ID:     "42",
+			Name:   "Mission: Test Suite",
+			GoNoGo: f9mission.VoteQuorum,
+		},
+	)
+	c.Assert(err, IsNil)
+	c.Assert(mission, NotNil)
+
+	t.mission = mission
+	addCrew(t.mission, c)
+}
+
+func (*TestSuite) TestNewMission(c *C) {
+	var m *f9mission.Mission
+	var err error
+
+	m, err = f9mission.NewMission(nil)
+	c.Check(err, ErrorMatches, "mission parameters cannot be nil")
+	c.Check(m, IsNil)
+
+	m, err = f9mission.NewMission(&f9mission.MissionParams{})
+	c.Check(err, ErrorMatches, "the ID of the mission cannot be an empty string")
+	c.Check(m, IsNil)
+
+	m, err = f9mission.NewMission(&f9mission.MissionParams{ID: "id"})
+	c.Check(err, IsNil)
+	c.Check(m, NotNil)
+}
+
+func (t *TestSuite) TestMission_Name(c *C) {
+	c.Check(t.mission.Name(), Equals, "Mission: Test Suite")
+}
+
+func (t *TestSuite) TestMission_ID(c *C) {
+	c.Check(t.mission.ID(), Equals, "42")
+}
+
+func (t *TestSuite) TestMission_GNGSetting(c *C) {
+	c.Check(t.mission.GNGSetting(), Equals, f9mission.VoteQuorum)
+}
+
+func (t *TestSuite) TestMission_Crew(c *C) {
+	var crew f9crew.Manifest
+
+	// get the crew
+	crew = t.mission.Crew()
+	c.Assert(len(crew), Equals, 3)
+
+	// sort the crew
+	crew.Sort()
+
+	c.Check(crew[0].Name(), Equals, "Bill Kerman")
+	c.Check(crew[0].HashedKey(), Equals, "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b")
+
+	c.Check(crew[1].Name(), Equals, "Bob Kerman")
+	c.Check(crew[1].HashedKey(), Equals, "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35")
+
+	c.Check(crew[2].Name(), Equals, "Jebediah Kerman")
+	c.Check(crew[2].HashedKey(), Equals, "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9")
+}
+
+func (t *TestSuite) TestMission_AddCrew(c *C) {
+	var err error
+
+	// generate a new crew member
+	person, err := f9crew.NewCrewMember("Valentina Kerman", "3")
+	c.Assert(err, IsNil)
+
+	// add the crew member
+	err = t.mission.AddCrew(person, false)
+	c.Assert(err, IsNil)
+
+	// get the crew and sort it
+	crew := t.mission.Crew()
+	c.Assert(len(crew), Equals, 4)
+
+	crew.Sort()
+
+	c.Check(crew[0].Name(), Equals, "Bill Kerman")
+	c.Check(crew[0].HashedKey(), Equals, "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b")
+
+	c.Check(crew[1].Name(), Equals, "Bob Kerman")
+	c.Check(crew[1].HashedKey(), Equals, "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35")
+
+	c.Check(crew[2].Name(), Equals, "Jebediah Kerman")
+	c.Check(crew[2].HashedKey(), Equals, "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9")
+
+	c.Check(crew[3].Name(), Equals, "Valentina Kerman")
+	c.Check(crew[3].HashedKey(), Equals, "4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce")
+
+	// assert error if crew present and we aren't replacing them
+	err = t.mission.AddCrew(person, false)
+	c.Check(err, Equals, f9mission.ErrCrewMemberAlreadyPresent)
+
+	// assert no error if crew present and we are replacing them
+	err = t.mission.AddCrew(person, true)
+	c.Check(err, IsNil)
+
+	// reset the mission
+	t.SetUpSuite(c)
+}
+
+func (t *TestSuite) TestMission_RemoveCrew(c *C) {
+	var person f9crew.Interface
+	var err error
+
+	// remove the person from the crew and make sure it is who we expect
+	person, err = t.mission.RemoveCrew("d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35")
+	c.Assert(err, IsNil)
+	c.Assert(person, NotNil)
+	c.Check(person.HashedKey(), Equals, "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35")
+	c.Check(person.Name(), Equals, "Bob Kerman")
+
+	// get the crew, and ensure it's the size we expect
+	crew := t.mission.Crew()
+	c.Check(len(crew), Equals, 2)
+
+	crew.Sort()
+
+	c.Check(crew[0].Name(), Equals, "Bill Kerman")
+	c.Check(crew[0].HashedKey(), Equals, "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b")
+
+	c.Check(crew[1].Name(), Equals, "Jebediah Kerman")
+	c.Check(crew[1].HashedKey(), Equals, "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9")
+
+	// reset the mission
+	t.SetUpSuite(c)
+}


### PR DESCRIPTION
This change adds the initial implementation of a mission. This does not complete the functionality of a mission, but seems to be a good starting point.

This change adds the initial interfaces used by a mission. That includes the interface for managing crew members, but also the interface for inspecting the parameters of a mission. In addition to the functionality being added, tests were written to confirm the new functionality.
