### PR TITLE
add Go/No-Go voting support to a mission

### DIFF
--- a/mission/mission.go
+++ b/mission/mission.go
@@ -13,14 +13,23 @@ import (
 type GNGSetting uint8
 
 const (
-	// VoteAll is the GoNoGo setting for requiring that all crew members vote Go.
-	VoteAll GNGSetting = iota
+	// GNGAll is the GoNoGo setting for requiring that all crew members vote Go.
+	GNGAll GNGSetting = iota
 
-	// VoteQuorum is the GoNoGo setting for requiring that only a quorum number
+	// GNGQuorum is the GoNoGo setting for requiring that only a quorum number
 	// of crew members vote for blastoff. If there are too few crew members to
 	// reach quorum without all voting "Go", it falls back to GNGAll mode.
-	VoteQuorum
+	GNGQuorum
 )
+
+// Tally is the map used for the current voting result tally. The key is the Vote kind.
+type Tally map[Vote]int
+
+// Results is the type for voting results per the crew member's answer. The key is
+// the crew member's HashedKey.
+type Results map[string]Vote
+
+var errUseNewMission = errors.New("use f9mission.NewMission() to create the *Mission struct")
 
 // ErrCrewMemberAlreadyPresent is the error returned from *Mission.AddUser
 // if the crew member is already present within the mission. Ths consumer
@@ -31,7 +40,15 @@ var ErrCrewMemberAlreadyPresent = errors.New("the user you are trying to add alr
 // is not assigned to this mission.
 var ErrCrewMemberNotPresent = errors.New("the crew member you've tried to remove is not present")
 
-var errUseNewMission = errors.New("use f9mission.NewMission() to create the *Mission struct")
+// ErrNoAssignedCrew is the error returned from Initiate() if a Go/No-Go was started
+// without there being any crew members assigned to the mission.
+var ErrNoAssignedCrew = errors.New("before Initiating a Go/No-Go the mission must have crew assigned")
+
+// ErrGNGInProgress is the error returned from Initiate() if a Go/No-Go is in progress.
+var ErrGNGInProgress = errors.New("Go/No-Go vote is currently in progress")
+
+// ErrGNGNotInProgress is the error returned from UpdateVote() if a Go/No-Go is not in progress
+var ErrGNGNotInProgress = errors.New("Go/No-Go vote is *NOT* currently in progress")
 
 // InterfaceManageCrew is the mission-specific interface for adding crew members.
 type InterfaceManageCrew interface {
@@ -57,6 +74,29 @@ type InterfaceManageCrew interface {
 	Crew() f9crew.Manifest
 }
 
+// InterfaceLaunchControl is the interface to the launch control systems.
+// This includes Go/No-Go voting
+type InterfaceLaunchControl interface {
+	// Initiate is the function used to start the launch sequence.
+	// By calling this function the mission enters the go/no-go state.
+	// The five-second countdown will begin once the proper number of
+	// "go" votes have been reached.
+	Initiate() error
+
+	// UpdateVote updates the vote of a crew member for the current mission.
+	// The bool value returned indicates whether there have been enough "Go"
+	// votes to proceed with blastoff.
+	//
+	// If the mission is not initialized this will return a ErrGNGNotInProgress
+	// error. If the crew member is not assigned to this mission, this will return
+	// a ErrCrewMembeverNotPresent error.
+	UpdateVote(hashedKey string, vote Vote) (bool, error)
+
+	// Tally returns the tally of votes and whether there are enough votes
+	// to proceed with the mission.
+	Tally() (Tally, bool)
+}
+
 // InterfaceAccessors is an interface type for accessor methods of the
 // mission parameters.
 type InterfaceAccessors interface {
@@ -76,6 +116,7 @@ type InterfaceAccessors interface {
 type Interface interface {
 	InterfaceManageCrew
 	InterfaceAccessors
+	InterfaceLaunchControl
 }
 
 // MissionParams is a struct that consists of the parameters for a mission.
@@ -92,8 +133,12 @@ type Mission struct {
 	name string
 	gng  GNGSetting
 
-	crew  map[string]f9crew.Interface
-	mapMu sync.Mutex
+	crew   map[string]f9crew.Interface
+	crewMu sync.Mutex
+
+	gngInProgress bool
+	gngResults    Results
+	gngMu         sync.Mutex
 }
 
 // NewMission is a function to provide a new mission with the provided parameters.
@@ -131,8 +176,8 @@ func (m *Mission) GNGSetting() GNGSetting { return m.gng }
 // returned contains unsorted values, but the returns value will
 // have a Sort() method.
 func (m *Mission) Crew() f9crew.Manifest {
-	m.mapMu.Lock()
-	defer m.mapMu.Unlock()
+	m.crewMu.Lock()
+	defer m.crewMu.Unlock()
 
 	manifest := make(f9crew.Manifest, len(m.crew))
 
@@ -166,8 +211,8 @@ func (m *Mission) AddCrew(crew f9crew.Interface, replace bool) error {
 		return errors.New("a crew member cannot be nil")
 	}
 
-	m.mapMu.Lock()
-	defer m.mapMu.Unlock()
+	m.crewMu.Lock()
+	defer m.crewMu.Unlock()
 
 	if _, ok := m.crew[crew.HashedKey()]; ok {
 		// if we aren't going to replace the user
@@ -193,8 +238,8 @@ func (m *Mission) RemoveCrew(hashedKey string) (f9crew.Interface, error) {
 		return nil, errors.New("hashedKey parameter cannot be an empty string")
 	}
 
-	m.mapMu.Lock()
-	defer m.mapMu.Unlock()
+	m.crewMu.Lock()
+	defer m.crewMu.Unlock()
 
 	crew, ok := m.crew[hashedKey]
 
@@ -205,4 +250,105 @@ func (m *Mission) RemoveCrew(hashedKey string) (f9crew.Interface, error) {
 	delete(m.crew, hashedKey)
 
 	return crew, nil
+}
+
+// Initiate is the function that starts the Go/No-Go call. At this point people
+// can start adding votes to the mission.
+func (m *Mission) Initiate() error {
+	m.crewMu.Lock()
+
+	n := len(m.crew)
+
+	m.crewMu.Unlock()
+
+	if n == 0 {
+		return ErrNoAssignedCrew
+	}
+
+	m.gngMu.Lock()
+	defer m.gngMu.Unlock()
+
+	if m.gngInProgress {
+		return ErrGNGInProgress
+	}
+
+	m.gngResults = make(Results)
+	m.gngInProgress = true
+
+	return nil
+}
+
+// UpdateVote updates the vote of a crew member for the current mission.
+// The bool value returned indicates whether there have been enough "Go"
+// votes to proceed with blastoff.
+//
+// If the mission is not initialized this will return a ErrGNGNotInProgress
+// error. If the crew member is not assigned to this mission, this will return
+// a ErrCrewMembeverNotPresent error.
+func (m *Mission) UpdateVote(hashedKey string, vote Vote) (bool, error) {
+	m.gngMu.Lock()
+	defer m.gngMu.Unlock()
+
+	if !m.gngInProgress {
+		return false, ErrGNGNotInProgress
+	}
+
+	m.crewMu.Lock()
+	defer m.crewMu.Unlock()
+
+	if _, ok := m.crew[hashedKey]; !ok {
+		return false, ErrCrewMemberNotPresent
+	}
+
+	m.gngResults[hashedKey] = vote
+
+	return m.isReady(m.tally()), nil
+}
+
+func (m *Mission) isReady(t Tally) bool {
+	mode := m.gng
+	numCrew := len(m.crew)
+
+	// if we have less than three crew members
+	// we cannot achieve quorum, so fall back to GNGAll.
+	if numCrew < 3 && mode == GNGQuorum {
+		mode = GNGAll
+	}
+
+	switch m.gng {
+	case GNGAll:
+		return t[VoteYes] == numCrew
+	case GNGQuorum:
+		quroum := (numCrew / 2) + 1
+		return t[VoteYes] >= quroum
+	default:
+		return false
+	}
+}
+
+func (m *Mission) tally() Tally {
+	tally := make(Tally)
+
+	for _, vote := range m.gngResults {
+		tally[vote]++
+	}
+
+	return tally
+}
+
+// Tally returns the tally of votes and whether there are enough votes
+// to proceed with the mission.
+func (m *Mission) Tally() (Tally, bool) {
+	if !m.gngInProgress {
+		return nil, false
+	}
+
+	m.gngMu.Lock()
+	defer m.gngMu.Unlock()
+
+	m.crewMu.Lock()
+	defer m.crewMu.Unlock()
+
+	tally := m.tally()
+	return tally, m.isReady(tally)
 }

--- a/mission/vote.go
+++ b/mission/vote.go
@@ -1,0 +1,37 @@
+package f9mission
+
+// Vote is the type for someone's vote
+type Vote uint8
+
+const (
+	// VoteAbstain is the default Vote value. It's for when a person has not
+	// voted yet. Abstaining is treated the same as a no. However, this is here
+	// to try and avoid breaking API compatibility in the future.
+	VoteAbstain Vote = iota
+
+	// VoteNo is the no Vote. It means the client is not ready.
+	VoteNo
+
+	// VoteYes is the yes Vote. The crew member is ready for blastoff!
+	VoteYes
+
+	// VoteAbort is the vote to abort. This is only available for use after the
+	// countdown has began. Depending on your mission parameters, a single abort
+	// may scrub the launch.
+	//
+	// TODO: implement this.
+	// VoteAbort
+)
+
+func (v Vote) String() string {
+	switch v {
+	case VoteAbstain:
+		return "Abstain"
+	case VoteNo:
+		return "No"
+	case VoteYes:
+		return "Yes"
+	default:
+		return "Unknown"
+	}
+}

--- a/mission/vote_test.go
+++ b/mission/vote_test.go
@@ -1,0 +1,13 @@
+package f9mission_test
+
+import (
+	"github.com/theckman/falcon9/mission"
+	. "gopkg.in/check.v1"
+)
+
+func (*TestSuite) TestVote_String(c *C) {
+	c.Check(f9mission.VoteAbstain.String(), Equals, "Abstain")
+	c.Check(f9mission.VoteNo.String(), Equals, "No")
+	c.Check(f9mission.VoteYes.String(), Equals, "Yes")
+	c.Check(f9mission.Vote(100).String(), Equals, "Unknown")
+}


### PR DESCRIPTION
This adds the initial implementation of voting on a mission's go/no-go status. This adds the `Initiate()`, `UpdateVote()`, and `Tally()` functions.
