### PR TITLE
remove erroneous logic and mode change from isReady()

### DIFF
--- a/mission/mission.go
+++ b/mission/mission.go
@@ -306,14 +306,7 @@ func (m *Mission) UpdateVote(hashedKey string, vote Vote) (bool, error) {
 }
 
 func (m *Mission) isReady(t Tally) bool {
-	mode := m.gng
 	numCrew := len(m.crew)
-
-	// if we have less than three crew members
-	// we cannot achieve quorum, so fall back to GNGAll.
-	if numCrew < 3 && mode == GNGQuorum {
-		mode = GNGAll
-	}
 
 	switch m.gng {
 	case GNGAll:


### PR DESCRIPTION
If we had too few nodes to achieve quorum, I was manually setting the GNG mode back to `GNGAll`. However, due to how arithmetic works this wasn't needed:

`N / 2 + 1` is the forumula for quorum. Using that forumla, where `N` is...

5 quorum is 3
4 quorum is 3
3 quorum is 2
2 quorum is 2
1 quorum is 1
