### PR TITLE
add support for aborting a mission

### DIFF
--- a/mission/mission_test.go
+++ b/mission/mission_test.go
@@ -2,9 +2,11 @@ package f9mission_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/theckman/falcon9/crew"
 	"github.com/theckman/falcon9/mission"
+	"github.com/theckman/go-fsm"
 
 	. "gopkg.in/check.v1"
 )
@@ -75,6 +77,22 @@ func (t *TestSuite) TestMission_GNGSetting(c *C) {
 	c.Check(t.mission.GNGSetting(), Equals, f9mission.GNGQuorum)
 }
 
+func (t *TestSuite) TestMission_CurrentState(c *C) {
+	// reset the mission
+	defer t.SetUpSuite(c)
+
+	//
+	// Test that the initial state is StateReady
+	//
+	c.Check(t.mission.CurrentState(), Equals, f9mission.StateReady)
+
+	//
+	// Test that the state changing is seen
+	//
+	c.Assert(t.mission.Initiate(), Equals, nil)
+	c.Check(t.mission.CurrentState(), Equals, f9mission.StateVoting)
+}
+
 func (t *TestSuite) TestMission_Crew(c *C) {
 	var crew f9crew.Manifest
 
@@ -134,6 +152,24 @@ func (t *TestSuite) TestMission_AddCrew(c *C) {
 	// assert no error if crew present and we are replacing them
 	err = t.mission.AddCrew(person, true)
 	c.Check(err, IsNil)
+
+	//
+	// Test that AddCrew will abort a blastoff
+	//
+	err = t.mission.Initiate()
+	c.Assert(err, IsNil)
+
+	ok, err := t.mission.UpdateVote("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b", f9mission.VoteYes)
+	c.Assert(err, IsNil)
+	c.Check(ok, Equals, false)
+
+	ok, err = t.mission.UpdateVote("5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9", f9mission.VoteYes)
+	c.Assert(err, IsNil)
+	c.Check(ok, Equals, false)
+
+	ok, err = t.mission.UpdateVote("4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce", f9mission.VoteYes)
+	c.Assert(err, IsNil)
+	c.Check(ok, Equals, true)
 }
 
 func (t *TestSuite) TestMission_RemoveCrew(c *C) {
@@ -166,6 +202,7 @@ func (t *TestSuite) TestMission_RemoveCrew(c *C) {
 func (*TestSuite) TestMission_Initiate(c *C) {
 	var m *f9mission.Mission
 	var err error
+	var state fsm.State
 
 	m, err = f9mission.NewMission(&f9mission.MissionParams{
 		ID:     "id",
@@ -186,17 +223,22 @@ func (*TestSuite) TestMission_Initiate(c *C) {
 	err = m.Initiate()
 	c.Check(err, IsNil)
 
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateVoting)
+
 	err = m.Initiate()
-	c.Check(err, Equals, f9mission.ErrGNGInProgress)
+	c.Check(err, Equals, f9mission.ErrMissionInProgress)
 }
 
 func (t *TestSuite) TestMission_UpdateVote(c *C) {
 	var bol bool
 	var err error
+	var state fsm.State
 
 	m, err := f9mission.NewMission(&f9mission.MissionParams{
-		ID:     "id",
-		GoNoGo: f9mission.GNGQuorum,
+		ID:                  "id",
+		GoNoGo:              f9mission.GNGQuorum,
+		BlastoffingCooldown: time.Millisecond * 100,
 	})
 	c.Check(err, IsNil)
 	c.Check(m, NotNil)
@@ -220,13 +262,19 @@ func (t *TestSuite) TestMission_UpdateVote(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(bol, Equals, false)
 
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateVoting)
+
 	bol, err = m.UpdateVote("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b", f9mission.VoteYes)
 	c.Assert(err, IsNil)
 	c.Check(bol, Equals, true)
 
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateBlastoffing)
+
 	//
 	// Test that adding third crew member, with GNGQuorum and two votes,
-	// marks the vote as being successful
+	// marks the vote as being successful and aborts
 	//
 	crew, err = f9crew.NewCrewMember("Bob Kerman", "2")
 	c.Assert(err, IsNil)
@@ -235,9 +283,12 @@ func (t *TestSuite) TestMission_UpdateVote(c *C) {
 	_, bol = m.Tally()
 	c.Check(bol, Equals, true)
 
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateAborted)
+
 	//
 	// Test that adding more crew, thus changing quorum, causes the
-	// vote to fall back to a fail.
+	// vote to fall back to a fail and aborts the mission.
 	//
 	crew, err = f9crew.NewCrewMember("Valentina Kerman", "3")
 	c.Assert(err, IsNil)
@@ -250,6 +301,30 @@ func (t *TestSuite) TestMission_UpdateVote(c *C) {
 	_, bol = m.Tally()
 	c.Check(bol, Equals, false)
 
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateAborted)
+
+	//
+	// RESTART VOTING AFTER PLANNED ABORT
+	//
+	err = m.Initiate()
+	c.Assert(err, IsNil)
+
+	// add votes back
+	bol, err = m.UpdateVote("5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9", f9mission.VoteYes)
+	c.Assert(err, IsNil)
+	c.Check(bol, Equals, false)
+
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateVoting)
+
+	bol, err = m.UpdateVote("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b", f9mission.VoteYes)
+	c.Assert(err, IsNil)
+	c.Check(bol, Equals, false)
+
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateVoting)
+
 	//
 	// Test that updating a cast vote doesn't change anything
 	//
@@ -257,17 +332,67 @@ func (t *TestSuite) TestMission_UpdateVote(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(bol, Equals, false)
 
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateVoting)
+
 	//
 	// Test that adding another Yes vote gets us quorum.
 	//
 	bol, err = m.UpdateVote("4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce", f9mission.VoteYes)
 	c.Assert(err, IsNil)
 	c.Check(bol, Equals, true)
+
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateBlastoffing)
+
+	//
+	// Test that adding an abort vote aborts
+	//
+	bol, err = m.UpdateVote("d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35", f9mission.VoteAbort)
+	c.Assert(err, IsNil)
+	c.Check(bol, Equals, false)
+
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateAborted)
+
+	//
+	// RESTART VOTING AFTER PLANNED ABORT
+	//
+	err = m.Initiate()
+	c.Assert(err, IsNil)
+
+	// add votes back
+	_, err = m.UpdateVote("5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9", f9mission.VoteYes)
+	c.Assert(err, IsNil)
+
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateVoting)
+
+	_, err = m.UpdateVote("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b", f9mission.VoteYes)
+	c.Assert(err, IsNil)
+
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateVoting)
+
+	_, err = m.UpdateVote("4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce", f9mission.VoteYes)
+	c.Assert(err, IsNil)
+
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateBlastoffing)
+
+	//
+	// Test that state transitions to StateFinished after the BlastoffingCooldown timer
+	//
+
+	time.Sleep(time.Millisecond * 110)
+	state = m.CurrentState()
+	c.Check(state, Equals, f9mission.StateFinished)
 }
 
 func (t *TestSuite) TestMission_Tally(c *C) {
-	var tally f9mission.Tally
+	var rdy bool
 	var err error
+	var tally f9mission.Tally
 
 	// reset the mission
 	defer t.SetUpSuite(c)
@@ -275,9 +400,10 @@ func (t *TestSuite) TestMission_Tally(c *C) {
 	//
 	// Test that nil is returned before Initiate() function is called
 	//
-	tally, _ = t.mission.Tally()
+	tally, rdy = t.mission.Tally()
 	c.Assert(len(tally), Equals, 0)
 	c.Check(tally, DeepEquals, f9mission.Tally(nil))
+	c.Check(rdy, Equals, false)
 
 	err = t.mission.Initiate()
 	c.Assert(err, Equals, nil)
@@ -285,9 +411,10 @@ func (t *TestSuite) TestMission_Tally(c *C) {
 	//
 	// Test that not nil is returned after Initiate() function is called
 	//
-	tally, _ = t.mission.Tally()
+	tally, rdy = t.mission.Tally()
 	c.Assert(len(tally), Equals, 0)
 	c.Check(tally, Not(DeepEquals), f9mission.Tally(nil))
+	c.Check(rdy, Equals, false)
 
 	//
 	// Test that Tally() can do maths
@@ -295,27 +422,61 @@ func (t *TestSuite) TestMission_Tally(c *C) {
 	_, err = t.mission.UpdateVote("5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9", f9mission.VoteYes)
 	c.Assert(err, IsNil)
 
-	tally, _ = t.mission.Tally()
+	tally, rdy = t.mission.Tally()
 	c.Assert(len(tally), Equals, 1)
+	c.Check(rdy, Equals, false)
 	c.Check(tally[f9mission.VoteYes], Equals, 1)
 	c.Check(tally[f9mission.VoteNo], Equals, 0)
 	c.Check(tally[f9mission.VoteAbstain], Equals, 0)
+	c.Check(tally[f9mission.VoteAbort], Equals, 0)
 
 	_, err = t.mission.UpdateVote("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b", f9mission.VoteNo)
 	c.Assert(err, IsNil)
 
-	tally, _ = t.mission.Tally()
+	tally, rdy = t.mission.Tally()
 	c.Assert(len(tally), Equals, 2)
+	c.Check(rdy, Equals, false)
 	c.Check(tally[f9mission.VoteYes], Equals, 1)
 	c.Check(tally[f9mission.VoteNo], Equals, 1)
 	c.Check(tally[f9mission.VoteAbstain], Equals, 0)
+	c.Check(tally[f9mission.VoteAbort], Equals, 0)
 
 	_, err = t.mission.UpdateVote("d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35", f9mission.VoteAbstain)
 	c.Assert(err, IsNil)
 
-	tally, _ = t.mission.Tally()
+	tally, rdy = t.mission.Tally()
 	c.Assert(len(tally), Equals, 3)
+	c.Check(rdy, Equals, false)
 	c.Check(tally[f9mission.VoteYes], Equals, 1)
 	c.Check(tally[f9mission.VoteNo], Equals, 1)
 	c.Check(tally[f9mission.VoteAbstain], Equals, 1)
+	c.Check(tally[f9mission.VoteAbort], Equals, 0)
+
+	//
+	// Test that Tally() marks rdy as true when ready
+	//
+	_, err = t.mission.UpdateVote("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b", f9mission.VoteYes)
+	c.Assert(err, IsNil)
+
+	tally, rdy = t.mission.Tally()
+	c.Assert(len(tally), Equals, 2)
+	c.Check(rdy, Equals, true)
+	c.Check(tally[f9mission.VoteYes], Equals, 2)
+	c.Check(tally[f9mission.VoteNo], Equals, 0)
+	c.Check(tally[f9mission.VoteAbstain], Equals, 1)
+	c.Check(tally[f9mission.VoteAbort], Equals, 0)
+
+	//
+	// Test that Tally() marks rdy as false when there is an abort
+	//
+	_, err = t.mission.UpdateVote("d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35", f9mission.VoteAbort)
+	c.Assert(err, IsNil)
+
+	tally, rdy = t.mission.Tally()
+	c.Assert(len(tally), Equals, 2)
+	c.Check(rdy, Equals, false)
+	c.Check(tally[f9mission.VoteYes], Equals, 2)
+	c.Check(tally[f9mission.VoteNo], Equals, 0)
+	c.Check(tally[f9mission.VoteAbstain], Equals, 0)
+	c.Check(tally[f9mission.VoteAbort], Equals, 1)
 }

--- a/mission/vote.go
+++ b/mission/vote.go
@@ -18,9 +18,7 @@ const (
 	// VoteAbort is the vote to abort. This is only available for use after the
 	// countdown has began. Depending on your mission parameters, a single abort
 	// may scrub the launch.
-	//
-	// TODO: implement this.
-	// VoteAbort
+	VoteAbort
 )
 
 func (v Vote) String() string {
@@ -31,6 +29,8 @@ func (v Vote) String() string {
 		return "No"
 	case VoteYes:
 		return "Yes"
+	case VoteAbort:
+		return "Abort"
 	default:
 		return "Unknown"
 	}

--- a/mission/vote_test.go
+++ b/mission/vote_test.go
@@ -9,5 +9,6 @@ func (*TestSuite) TestVote_String(c *C) {
 	c.Check(f9mission.VoteAbstain.String(), Equals, "Abstain")
 	c.Check(f9mission.VoteNo.String(), Equals, "No")
 	c.Check(f9mission.VoteYes.String(), Equals, "Yes")
+	c.Check(f9mission.VoteAbort.String(), Equals, "Abort")
 	c.Check(f9mission.Vote(100).String(), Equals, "Unknown")
 }


### PR DESCRIPTION
This change converts the `f9mission.Mission` struct to use an `fsm.Machine` struct to maintain mission state. By using this state machine, we can be a bit more fine-grained with the states of the mission.

Once we had the state machine, it made it easier to implement the idea of aborting a blastoff. So we add the `VoteAbort` vote type, and implement the logic around aborting a mission.

The logic that was added is being tested in the unit tests.
