### PR TITLE
add registry for mission control

### DIFF
--- a/mission_control/mission_control_test.go
+++ b/mission_control/mission_control_test.go
@@ -1,0 +1,31 @@
+package f9missioncontrol_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct {
+	seeded bool
+}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func seedRand(c *C) {
+	seed := time.Now().UnixNano()
+	rand.Seed(seed)
+	fmt.Printf("random seed: %d\n", seed)
+}
+
+func (t *TestSuite) SetUpSuite(c *C) {
+	if !t.seeded {
+		seedRand(c)
+		t.seeded = true
+	}
+}

--- a/mission_control/registry.go
+++ b/mission_control/registry.go
@@ -1,0 +1,82 @@
+package f9missioncontrol
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/theckman/falcon9/mission"
+)
+
+type missionRegistry struct {
+	missions map[uint16]f9mission.Interface
+}
+
+var (
+	registry   missionRegistry
+	registryMu sync.RWMutex
+)
+
+// GetMission returns a mission, based on the ID, if one has been created. If the
+// mission doesn't exist this just returns nil.
+func GetMission(id uint16) f9mission.Interface {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	ifc, ok := registry.missions[id]
+
+	if !ok {
+		return nil
+	}
+
+	return ifc
+}
+
+// AddMission is a function to add a mission to the registry. This will only
+// return an error when the registry already has a mission with that ID.
+func AddMission(id uint16, mission f9mission.Interface) error {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if _, ok := registry.missions[id]; ok {
+		return fmt.Errorf("Mission with ID %d already registered", id)
+	}
+
+	registry.missions[id] = mission
+
+	return nil
+}
+
+// RemoveMission purges a mission from the mission registry. If the mission existed
+// this will return the mission, otherwise it will return nil.
+func RemoveMission(id uint16) f9mission.Interface {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if mission, ok := registry.missions[id]; ok {
+		delete(registry.missions, id)
+		return mission
+	}
+
+	return nil
+}
+
+// ListMissions returns a slice of the mission IDs. They are in no particular order.
+func ListMissions() []uint16 {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	slice := make([]uint16, len(registry.missions))
+
+	var i int
+
+	for id := range registry.missions {
+		slice[i] = id
+		i++
+	}
+
+	return slice
+}
+
+func init() {
+	registry.missions = make(map[uint16]f9mission.Interface)
+}

--- a/mission_control/registry_test.go
+++ b/mission_control/registry_test.go
@@ -1,0 +1,159 @@
+package f9missioncontrol_test
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/theckman/falcon9/mission"
+	"github.com/theckman/falcon9/mission_control"
+
+	. "gopkg.in/check.v1"
+)
+
+const maxUint16 = int(^uint16(0))
+
+func randUint16() uint16 {
+	return uint16(rand.Intn(maxUint16))
+}
+
+func tearDownRegistry(c *C) {
+	ids := f9missioncontrol.ListMissions()
+
+	for _, id := range ids {
+		mission := f9missioncontrol.RemoveMission(id)
+		c.Check(mission, NotNil)
+	}
+}
+
+func (*TestSuite) TestAddMission(c *C) {
+	var err error
+
+	// clean up the registry
+	defer tearDownRegistry(c)
+
+	mission := &f9mission.Mission{}
+	id := randUint16()
+
+	err = f9missioncontrol.AddMission(id, mission)
+	c.Assert(err, IsNil)
+
+	mIfc := f9missioncontrol.GetMission(id)
+	c.Check(mIfc, NotNil)
+
+	//
+	// Test that you can't register it twice
+	//
+	err = f9missioncontrol.AddMission(id, mission)
+	c.Assert(err, NotNil)
+}
+
+func (*TestSuite) TestListMissions(c *C) {
+	var missions []uint16
+
+	// clean up the registry
+	defer tearDownRegistry(c)
+
+	set := make(map[uint16]struct{})
+
+	// set up the registry for this test
+	for i := 0; i < 5; i++ {
+		id := randUint16()
+
+		mp := &f9mission.MissionParams{
+			ID:   fmt.Sprintf("testID-%d", id),
+			Name: fmt.Sprintf("testName-%d", id),
+		}
+
+		mission, err := f9mission.NewMission(mp)
+		c.Assert(err, IsNil)
+
+		err = f9missioncontrol.AddMission(id, mission)
+		c.Assert(err, IsNil)
+
+		set[id] = struct{}{}
+	}
+
+	missions = f9missioncontrol.ListMissions()
+	c.Assert(len(missions), Equals, 5)
+
+	for _, id := range missions {
+		_, ok := set[id]
+		c.Assert(ok, Equals, true)
+
+		missionIfc := f9missioncontrol.GetMission(id)
+		c.Check(missionIfc.Name(), Equals, fmt.Sprintf("testName-%d", id))
+		c.Check(missionIfc.ID(), Equals, fmt.Sprintf("testID-%d", id))
+	}
+}
+
+func (*TestSuite) TestGetMission(c *C) {
+	var mIfc f9mission.Interface
+	var err error
+
+	// clean up the registry
+	defer tearDownRegistry(c)
+
+	mp := &f9mission.MissionParams{
+		ID:   "testID",
+		Name: "testName",
+	}
+
+	mission, err := f9mission.NewMission(mp)
+	c.Assert(err, IsNil)
+
+	id := randUint16()
+
+	err = f9missioncontrol.AddMission(id, mission)
+	c.Assert(err, IsNil)
+
+	//
+	// Test when mission exists
+	//
+	mIfc = f9missioncontrol.GetMission(id)
+	c.Assert(mIfc, NotNil)
+	c.Check(mIfc.Name(), Equals, "testName")
+	c.Check(mIfc.ID(), Equals, "testID")
+
+	//
+	// Test when mission does not exist
+	//
+	mIfc = f9missioncontrol.GetMission(id + 1)
+	c.Assert(mIfc, IsNil)
+}
+
+func (*TestSuite) TestRemoveMission(c *C) {
+	var err error
+
+	// clean up the registry
+	defer tearDownRegistry(c)
+
+	mp := &f9mission.MissionParams{
+		ID:   "testID",
+		Name: "testName",
+	}
+
+	mission, err := f9mission.NewMission(mp)
+	c.Assert(err, IsNil)
+
+	id := randUint16()
+
+	err = f9missioncontrol.AddMission(id, mission)
+	c.Assert(err, IsNil)
+
+	c.Check(len(f9missioncontrol.ListMissions()), Equals, 1)
+
+	//
+	// Test when mission does not exist
+	//
+	mIfc := f9missioncontrol.RemoveMission(id + 1)
+	c.Check(mIfc, IsNil)
+
+	//
+	// Test when mission exists
+	//
+	mIfc = f9missioncontrol.RemoveMission(id)
+	c.Assert(mIfc, NotNil)
+	c.Check(mIfc.Name(), Equals, "testName")
+	c.Check(mIfc.ID(), Equals, "testID")
+	c.Check(len(f9missioncontrol.ListMissions()), Equals, 0)
+}


### PR DESCRIPTION
`Mission Control` will need to manage all ongoing missions. As such, a registry will need to exist of current missions by their ID. This creates that registry, and allows to add, get, remove, and list all missions.

The unit tests for the repective functions were added as well.
