### PR TITLE
convert mission ID from a string to a uint32

### DIFF
--- a/mission/mission.go
+++ b/mission/mission.go
@@ -115,7 +115,7 @@ type InterfaceAccessors interface {
 	Name() string
 
 	// ID returns the unique identifier of the mission.
-	ID() string
+	ID() uint32
 
 	// GNGSetting returns the Go/No-Go setting for the mission.
 	GNGSetting() GNGSetting
@@ -135,7 +135,7 @@ type Interface interface {
 
 // MissionParams is a struct that consists of the parameters for a mission.
 type MissionParams struct {
-	ID                  string
+	ID                  uint32
 	GoNoGo              GNGSetting
 	Name                string
 	BlastoffingCooldown time.Duration
@@ -144,7 +144,7 @@ type MissionParams struct {
 // Mission is the struct that implements the f9mission.Interface interface. This
 // represents a falcon9 mission and all of its parameters.
 type Mission struct {
-	id   string
+	id   uint32
 	name string
 	gng  GNGSetting
 
@@ -203,10 +203,6 @@ func NewMission(mp *MissionParams) (*Mission, error) {
 		return nil, errors.New("mission parameters cannot be nil")
 	}
 
-	if mp.ID == "" {
-		return nil, errors.New("the ID of the mission cannot be an empty string")
-	}
-
 	if mp.BlastoffingCooldown == 0 {
 		mp.BlastoffingCooldown = time.Second * 10
 	}
@@ -232,7 +228,7 @@ func NewMission(mp *MissionParams) (*Mission, error) {
 func (m *Mission) Name() string { return m.name }
 
 // ID returns the unique identifier of the mission.
-func (m *Mission) ID() string { return m.id }
+func (m *Mission) ID() uint32 { return m.id }
 
 // GNGSetting returns the Go/No-Go setting for the mission.
 func (m *Mission) GNGSetting() GNGSetting { return m.gng }

--- a/mission/mission_test.go
+++ b/mission/mission_test.go
@@ -36,7 +36,7 @@ func addCrew(m *f9mission.Mission, c *C) {
 func (t *TestSuite) SetUpSuite(c *C) {
 	mission, err := f9mission.NewMission(
 		&f9mission.MissionParams{
-			ID:     "42",
+			ID:     42,
 			Name:   "Mission: Test Suite",
 			GoNoGo: f9mission.GNGQuorum,
 		},
@@ -57,10 +57,6 @@ func (*TestSuite) TestNewMission(c *C) {
 	c.Check(m, IsNil)
 
 	m, err = f9mission.NewMission(&f9mission.MissionParams{})
-	c.Check(err, ErrorMatches, "the ID of the mission cannot be an empty string")
-	c.Check(m, IsNil)
-
-	m, err = f9mission.NewMission(&f9mission.MissionParams{ID: "id"})
 	c.Check(err, IsNil)
 	c.Check(m, NotNil)
 }
@@ -70,7 +66,7 @@ func (t *TestSuite) TestMission_Name(c *C) {
 }
 
 func (t *TestSuite) TestMission_ID(c *C) {
-	c.Check(t.mission.ID(), Equals, "42")
+	c.Check(t.mission.ID(), Equals, uint32(42))
 }
 
 func (t *TestSuite) TestMission_GNGSetting(c *C) {
@@ -205,7 +201,6 @@ func (*TestSuite) TestMission_Initiate(c *C) {
 	var state fsm.State
 
 	m, err = f9mission.NewMission(&f9mission.MissionParams{
-		ID:     "id",
 		GoNoGo: f9mission.GNGQuorum,
 	})
 	c.Check(err, IsNil)
@@ -236,7 +231,6 @@ func (t *TestSuite) TestMission_UpdateVote(c *C) {
 	var state fsm.State
 
 	m, err := f9mission.NewMission(&f9mission.MissionParams{
-		ID:                  "id",
 		GoNoGo:              f9mission.GNGQuorum,
 		BlastoffingCooldown: time.Millisecond * 100,
 	})

--- a/mission_control/registry.go
+++ b/mission_control/registry.go
@@ -8,7 +8,7 @@ import (
 )
 
 type missionRegistry struct {
-	missions map[uint16]f9mission.Interface
+	missions map[uint32]f9mission.Interface
 }
 
 var (
@@ -18,7 +18,7 @@ var (
 
 // GetMission returns a mission, based on the ID, if one has been created. If the
 // mission doesn't exist this just returns nil.
-func GetMission(id uint16) f9mission.Interface {
+func GetMission(id uint32) f9mission.Interface {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
@@ -33,7 +33,7 @@ func GetMission(id uint16) f9mission.Interface {
 
 // AddMission is a function to add a mission to the registry. This will only
 // return an error when the registry already has a mission with that ID.
-func AddMission(id uint16, mission f9mission.Interface) error {
+func AddMission(id uint32, mission f9mission.Interface) error {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 
@@ -48,7 +48,7 @@ func AddMission(id uint16, mission f9mission.Interface) error {
 
 // RemoveMission purges a mission from the mission registry. If the mission existed
 // this will return the mission, otherwise it will return nil.
-func RemoveMission(id uint16) f9mission.Interface {
+func RemoveMission(id uint32) f9mission.Interface {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 
@@ -61,11 +61,11 @@ func RemoveMission(id uint16) f9mission.Interface {
 }
 
 // ListMissions returns a slice of the mission IDs. They are in no particular order.
-func ListMissions() []uint16 {
+func ListMissions() []uint32 {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
-	slice := make([]uint16, len(registry.missions))
+	slice := make([]uint32, len(registry.missions))
 
 	var i int
 
@@ -78,5 +78,5 @@ func ListMissions() []uint16 {
 }
 
 func init() {
-	registry.missions = make(map[uint16]f9mission.Interface)
+	registry.missions = make(map[uint32]f9mission.Interface)
 }

--- a/mission_control/registry_test.go
+++ b/mission_control/registry_test.go
@@ -10,10 +10,10 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-const maxUint16 = int(^uint16(0))
+const maxUint32 = int(^uint32(0))
 
-func randUint16() uint16 {
-	return uint16(rand.Intn(maxUint16))
+func randUint32() uint32 {
+	return uint32(rand.Intn(maxUint32))
 }
 
 func tearDownRegistry(c *C) {
@@ -32,7 +32,7 @@ func (*TestSuite) TestAddMission(c *C) {
 	defer tearDownRegistry(c)
 
 	mission := &f9mission.Mission{}
-	id := randUint16()
+	id := randUint32()
 
 	err = f9missioncontrol.AddMission(id, mission)
 	c.Assert(err, IsNil)
@@ -48,19 +48,19 @@ func (*TestSuite) TestAddMission(c *C) {
 }
 
 func (*TestSuite) TestListMissions(c *C) {
-	var missions []uint16
+	var missions []uint32
 
 	// clean up the registry
 	defer tearDownRegistry(c)
 
-	set := make(map[uint16]struct{})
+	set := make(map[uint32]struct{})
 
 	// set up the registry for this test
 	for i := 0; i < 5; i++ {
-		id := randUint16()
+		id := randUint32()
 
 		mp := &f9mission.MissionParams{
-			ID:   fmt.Sprintf("testID-%d", id),
+			ID:   id,
 			Name: fmt.Sprintf("testName-%d", id),
 		}
 
@@ -82,7 +82,7 @@ func (*TestSuite) TestListMissions(c *C) {
 
 		missionIfc := f9missioncontrol.GetMission(id)
 		c.Check(missionIfc.Name(), Equals, fmt.Sprintf("testName-%d", id))
-		c.Check(missionIfc.ID(), Equals, fmt.Sprintf("testID-%d", id))
+		c.Check(missionIfc.ID(), Equals, id)
 	}
 }
 
@@ -93,15 +93,15 @@ func (*TestSuite) TestGetMission(c *C) {
 	// clean up the registry
 	defer tearDownRegistry(c)
 
+	id := randUint32()
+
 	mp := &f9mission.MissionParams{
-		ID:   "testID",
+		ID:   id,
 		Name: "testName",
 	}
 
 	mission, err := f9mission.NewMission(mp)
 	c.Assert(err, IsNil)
-
-	id := randUint16()
 
 	err = f9missioncontrol.AddMission(id, mission)
 	c.Assert(err, IsNil)
@@ -112,7 +112,7 @@ func (*TestSuite) TestGetMission(c *C) {
 	mIfc = f9missioncontrol.GetMission(id)
 	c.Assert(mIfc, NotNil)
 	c.Check(mIfc.Name(), Equals, "testName")
-	c.Check(mIfc.ID(), Equals, "testID")
+	c.Check(mIfc.ID(), Equals, id)
 
 	//
 	// Test when mission does not exist
@@ -127,15 +127,15 @@ func (*TestSuite) TestRemoveMission(c *C) {
 	// clean up the registry
 	defer tearDownRegistry(c)
 
+	id := randUint32()
+
 	mp := &f9mission.MissionParams{
-		ID:   "testID",
+		ID:   id,
 		Name: "testName",
 	}
 
 	mission, err := f9mission.NewMission(mp)
 	c.Assert(err, IsNil)
-
-	id := randUint16()
 
 	err = f9missioncontrol.AddMission(id, mission)
 	c.Assert(err, IsNil)
@@ -154,6 +154,6 @@ func (*TestSuite) TestRemoveMission(c *C) {
 	mIfc = f9missioncontrol.RemoveMission(id)
 	c.Assert(mIfc, NotNil)
 	c.Check(mIfc.Name(), Equals, "testName")
-	c.Check(mIfc.ID(), Equals, "testID")
+	c.Check(mIfc.ID(), Equals, id)
 	c.Check(len(f9missioncontrol.ListMissions()), Equals, 0)
 }


### PR DESCRIPTION
The mission ID is going to be sent over the wire. Initially, I was going to use a UUID or something, but that is going to require a lot more data be sent across the wire. Instead, let's use four bytes (uint32) to generate a pseudo-random identification number. `uint32` should contain enough values for the server to operate without collisions.
