### PR TITLE
convert the registry to handle *MissionControl structs

### DIFF
--- a/mission_control/mission_control.go
+++ b/mission_control/mission_control.go
@@ -1,0 +1,20 @@
+package f9missioncontrol
+
+import (
+	"net"
+
+	"github.com/theckman/falcon9/crew"
+	"github.com/theckman/falcon9/mission"
+)
+
+type client struct {
+	conn net.Conn
+	out  chan []byte
+	crew f9crew.Interface
+}
+
+// MissionControl is the controller of a mission.
+type MissionControl struct {
+	Mission f9mission.Interface
+	clients map[string]*client
+}

--- a/mission_control/registry.go
+++ b/mission_control/registry.go
@@ -3,12 +3,10 @@ package f9missioncontrol
 import (
 	"fmt"
 	"sync"
-
-	"github.com/theckman/falcon9/mission"
 )
 
 type missionRegistry struct {
-	missions map[uint32]f9mission.Interface
+	missions map[uint32]*MissionControl
 }
 
 var (
@@ -18,7 +16,7 @@ var (
 
 // GetMission returns a mission, based on the ID, if one has been created. If the
 // mission doesn't exist this just returns nil.
-func GetMission(id uint32) f9mission.Interface {
+func GetMission(id uint32) *MissionControl {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
@@ -33,7 +31,7 @@ func GetMission(id uint32) f9mission.Interface {
 
 // AddMission is a function to add a mission to the registry. This will only
 // return an error when the registry already has a mission with that ID.
-func AddMission(id uint32, mission f9mission.Interface) error {
+func AddMission(id uint32, mission *MissionControl) error {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 
@@ -48,7 +46,7 @@ func AddMission(id uint32, mission f9mission.Interface) error {
 
 // RemoveMission purges a mission from the mission registry. If the mission existed
 // this will return the mission, otherwise it will return nil.
-func RemoveMission(id uint32) f9mission.Interface {
+func RemoveMission(id uint32) *MissionControl {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 
@@ -78,5 +76,5 @@ func ListMissions() []uint32 {
 }
 
 func init() {
-	registry.missions = make(map[uint32]f9mission.Interface)
+	registry.missions = make(map[uint32]*MissionControl)
 }

--- a/mission_control/registry_test.go
+++ b/mission_control/registry_test.go
@@ -34,7 +34,9 @@ func (*TestSuite) TestAddMission(c *C) {
 	mission := &f9mission.Mission{}
 	id := randUint32()
 
-	err = f9missioncontrol.AddMission(id, mission)
+	mc := &f9missioncontrol.MissionControl{Mission: mission}
+
+	err = f9missioncontrol.AddMission(id, mc)
 	c.Assert(err, IsNil)
 
 	mIfc := f9missioncontrol.GetMission(id)
@@ -43,7 +45,7 @@ func (*TestSuite) TestAddMission(c *C) {
 	//
 	// Test that you can't register it twice
 	//
-	err = f9missioncontrol.AddMission(id, mission)
+	err = f9missioncontrol.AddMission(id, mc)
 	c.Assert(err, NotNil)
 }
 
@@ -67,7 +69,9 @@ func (*TestSuite) TestListMissions(c *C) {
 		mission, err := f9mission.NewMission(mp)
 		c.Assert(err, IsNil)
 
-		err = f9missioncontrol.AddMission(id, mission)
+		mc := &f9missioncontrol.MissionControl{Mission: mission}
+
+		err = f9missioncontrol.AddMission(id, mc)
 		c.Assert(err, IsNil)
 
 		set[id] = struct{}{}
@@ -80,14 +84,14 @@ func (*TestSuite) TestListMissions(c *C) {
 		_, ok := set[id]
 		c.Assert(ok, Equals, true)
 
-		missionIfc := f9missioncontrol.GetMission(id)
-		c.Check(missionIfc.Name(), Equals, fmt.Sprintf("testName-%d", id))
-		c.Check(missionIfc.ID(), Equals, id)
+		mc := f9missioncontrol.GetMission(id)
+		c.Check(mc.Mission.Name(), Equals, fmt.Sprintf("testName-%d", id))
+		c.Check(mc.Mission.ID(), Equals, id)
 	}
 }
 
 func (*TestSuite) TestGetMission(c *C) {
-	var mIfc f9mission.Interface
+	var mIfc *f9missioncontrol.MissionControl
 	var err error
 
 	// clean up the registry
@@ -103,7 +107,9 @@ func (*TestSuite) TestGetMission(c *C) {
 	mission, err := f9mission.NewMission(mp)
 	c.Assert(err, IsNil)
 
-	err = f9missioncontrol.AddMission(id, mission)
+	mc := &f9missioncontrol.MissionControl{Mission: mission}
+
+	err = f9missioncontrol.AddMission(id, mc)
 	c.Assert(err, IsNil)
 
 	//
@@ -111,8 +117,8 @@ func (*TestSuite) TestGetMission(c *C) {
 	//
 	mIfc = f9missioncontrol.GetMission(id)
 	c.Assert(mIfc, NotNil)
-	c.Check(mIfc.Name(), Equals, "testName")
-	c.Check(mIfc.ID(), Equals, id)
+	c.Check(mIfc.Mission.Name(), Equals, "testName")
+	c.Check(mIfc.Mission.ID(), Equals, id)
 
 	//
 	// Test when mission does not exist
@@ -137,7 +143,9 @@ func (*TestSuite) TestRemoveMission(c *C) {
 	mission, err := f9mission.NewMission(mp)
 	c.Assert(err, IsNil)
 
-	err = f9missioncontrol.AddMission(id, mission)
+	mc := &f9missioncontrol.MissionControl{Mission: mission}
+
+	err = f9missioncontrol.AddMission(id, mc)
 	c.Assert(err, IsNil)
 
 	c.Check(len(f9missioncontrol.ListMissions()), Equals, 1)
@@ -153,7 +161,7 @@ func (*TestSuite) TestRemoveMission(c *C) {
 	//
 	mIfc = f9missioncontrol.RemoveMission(id)
 	c.Assert(mIfc, NotNil)
-	c.Check(mIfc.Name(), Equals, "testName")
-	c.Check(mIfc.ID(), Equals, id)
+	c.Check(mIfc.Mission.Name(), Equals, "testName")
+	c.Check(mIfc.Mission.ID(), Equals, id)
 	c.Check(len(f9missioncontrol.ListMissions()), Equals, 0)
 }


### PR DESCRIPTION
The MissionControl struct is the thing that is going to handle the communication between the crew (clients) and the mission parameters. This will also handle the registering of new crew members.

So it makes sense for the registry to track those.
